### PR TITLE
add test for the explore page text

### DIFF
--- a/FrontEnd/app/(tabs)/explore.tsx
+++ b/FrontEnd/app/(tabs)/explore.tsx
@@ -64,9 +64,7 @@ export default function MenuScreen() {
     const loadMenuItems = async () => {
       try 
       {
-        console.log('Fetching from:', `${BACKEND_URL}/menuItems`);
         const response = await axios.get(`${BACKEND_URL}/menuItems`);
-        console.log('Response data:', response.data);
         const items = Array.isArray(response.data.foundItems) ? response.data.foundItems : [];
         setMenuItems(items);
         
@@ -77,7 +75,6 @@ export default function MenuScreen() {
           mainDishes: items.filter(item => item.category === 'Main'),
           desserts: items.filter(item => item.category === 'Dessert')
         };
-        console.log('Categorized items:', categorized);
         setCategorizedItems(categorized);
       } 
       

--- a/FrontEnd/app/__tests__/Explore-test.tsx
+++ b/FrontEnd/app/__tests__/Explore-test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import MenuScreen from '@/app/(tabs)/explore';
+
+
+jest.mock('expo-font', () => ({
+  loadAsync: jest.fn(() => Promise.resolve()),
+  isLoaded: jest.fn(() => true),
+}));
+
+
+describe('MenuScreen', () => {
+
+  test('should render MenuScreen text', () => {
+    // Render the HomeScreen component wrapped in the navigator
+    const {getByText} = render(
+      <NavigationContainer>
+      <MenuScreen />
+      </NavigationContainer>);
+    
+    expect(getByText("Today's Menu")).toBeTruthy();
+    
+    expect(getByText("Appetizers")).toBeTruthy();
+    
+    expect(getByText("Main Dishes")).toBeTruthy();
+    
+    expect(getByText("Desserts")).toBeTruthy();
+     
+  });
+
+
+});


### PR DESCRIPTION
Add tests for the text of the explore page. The components texts are not tested because they are not loaded on file load.
get rid of console logs as the tests don't like it. (they logged which endpoint in the backend was hit and what it gave you)